### PR TITLE
Remove translatesAutoresizingMaskIntoConstraints

### DIFF
--- a/GraphicLibrary/RadioButton.swift
+++ b/GraphicLibrary/RadioButton.swift
@@ -68,7 +68,7 @@ class RadioButton: UIControl {
     /// Setup the view initially
     private func setupViews() {
         self.subviews.forEach { $0.removeFromSuperview() }
-        self.translatesAutoresizingMaskIntoConstraints = false
+//        self.translatesAutoresizingMaskIntoConstraints = false
         self.autoresizesSubviews = false
 
 


### PR DESCRIPTION
A view should never set/override its own `translatesAutoresizingMaskIntoConstraints`. IB (or the view controller, if doing it programmatically) is responsible for configuring this. Sure, if you want to use auto layout for subviews, fine, do that, but never for the view in question.